### PR TITLE
Backend Server RPC Integration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -26,6 +26,7 @@ import {
 } from 'react-native/Libraries/NewAppScreen';
 import TabNavigation from './src/UI/Components/TabNavigation';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { OnboardingRpcCaller } from './src/Rpc/OnboardingRpcCaller';
 
 type SectionProps = PropsWithChildren<{
   title: string;
@@ -59,14 +60,23 @@ function Section({children, title}: SectionProps): React.JSX.Element {
 
 function App(): React.JSX.Element {
   const isDarkMode = useColorScheme() === 'dark';
-
+  // Enabling Text Encoder for safe RPC Calls
+  global.TextEncoder = require('text-encoding').TextEncoder;
+  
   const backgroundStyle = {
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
   };
-
+  
+  OnboardingRpcCaller.getCurrentOnboardingStage().then(
+    (resp)=> {
+    console.log(resp.currentStage)
+  }
+  ).catch(
+    (err)=> {
+    console.log(err)
+  }
+  )
   return (
-      
-    
     <SafeAreaView style={backgroundStyle}>
       <StatusBar
         barStyle={isDarkMode ? 'light-content' : 'dark-content'}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
-        minSdkVersion = 23
+        minSdkVersion = 25
         compileSdkVersion = 34
         targetSdkVersion = 34
         ndkVersion = "26.1.10909125"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.8.22",
     "@grpc/proto-loader": "^0.7.13",
+    "@mitch528/react-native-grpc": "^0.1.10",
+    "@protobuf-ts/runtime-rpc": "^2.9.4",
     "@react-navigation/bottom-tabs": "^6.5.20",
     "@react-navigation/native": "^6.1.17",
     "long": "^5.2.3",
@@ -19,7 +21,8 @@
     "react": "18.2.0",
     "react-native": "0.74.1",
     "react-native-safe-area-context": "^4.10.4",
-    "react-native-screens": "^3.31.1"
+    "react-native-screens": "^3.31.1",
+    "text-encoding": "^0.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/Configs/server-config.yaml
+++ b/src/Configs/server-config.yaml
@@ -1,0 +1,51 @@
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: backend
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: grpc_backend
+                http_filters:
+                  - name: envoy.filters.http.cors
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                      allow_origin_string_match:
+                        - prefix: "*"
+                      allow_methods: "GET, PUT, DELETE, POST, OPTIONS"
+                      allow_headers: "keep-alive, user-agent, cache-control, content-type, content-transfer-encoding, x-accept-content-transfer-encoding, x-accept-response-streaming, grpc-timeout, x-user-agent, x-grpc-web, grpc-web-client"
+                      expose_headers: "grpc-status, grpc-message"
+                      max_age: "1728000"
+                      allow_credentials: true
+                  - name: envoy.filters.http.router
+  clusters:
+    - name: grpc_backend
+      connect_timeout: 0.25s
+      type: logical_dns
+      http2_protocol_options: {}
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: grpc_backend
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 50051  # Replace with your gRPC server port

--- a/src/Rpc/NativeClient.ts
+++ b/src/Rpc/NativeClient.ts
@@ -1,0 +1,38 @@
+import {GrpcClient} from '@mitch528/react-native-grpc';
+import { FrontendServiceClient } from '../gencode/protos-frontend/frontend/FrontendService.client';
+import { RNGrpcTransport } from './RNTransport';
+
+
+
+const nativeClientInstance = GrpcClient
+
+/**
+ * function to initialize the native Grpc Client using which we can have any Client Server instance created
+ * Please make sure that you change the value of the host in set host while testing
+ * There are certain errors which can be faced while using the host , you need to catch the error wherever you
+ * are getting the promise of the response to debug those errors
+ */
+function initializeNativeClient(){
+    // TODO : use the host from the yaml config file
+    nativeClientInstance.setHost('0.tcp.in.ngrok.io:12935');
+    // TODO : use this value from yaml config file
+    nativeClientInstance.setInsecure(true);
+
+}
+
+initializeNativeClient()
+
+/**
+ * Native Client exportion for data sharing for the server instanced data for now, we can remove this 
+ * once we are in a stable position on the Service Client side
+ */
+export const NativeClient = nativeClientInstance
+
+/**
+ * This is the Service Client which can be directly used to make RPC calls with the request parameters 
+ * and the headers, metadata for the RPC call happening
+ * This Client wont be able to support streaming for now as we have not implemented in the {RNGrpcTransport}
+ */
+export const ServiceClient = new FrontendServiceClient(
+    new RNGrpcTransport(NativeClient),
+  );

--- a/src/Rpc/OnboardingRpcCaller.ts
+++ b/src/Rpc/OnboardingRpcCaller.ts
@@ -1,21 +1,17 @@
-import {GrpcClient} from '@mitch528/react-native-grpc';
-import {GetCurrentOnboardingStageResponse} from '../gencode/protos-frontend/onboarding/rpc';
-import {FrontendServiceClient} from '../gencode/protos-frontend/frontend/FrontendService.client';
-import {RNGrpcTransport} from './RNTransport';
 import {EmptyRequest} from '../gencode/protos-frontend/generic/GenericMessages';
+import { NativeClient, ServiceClient } from './NativeClient';
 
+/**
+ * Class that can support the calling of RPCs if you define functions for RPC calls here
+ */
 class OnboardingRpcHelper {
+    /**
+     * function to call the getCurrentOnboardingStage RPC from the Backend Server
+     * @returns promise of the GetCurrentOnboardingStage DTO 
+     */
   public async getCurrentOnboardingStage() {
-    const nativeClient = GrpcClient;
-    nativeClient.setHost('0.tcp.in.ngrok.io:12935');
-    nativeClient.setInsecure(true);
-    
-    const serviceClient = new FrontendServiceClient(
-      new RNGrpcTransport(nativeClient),
-    );
-    
-    console.log('port number :',await nativeClient.getHost())
-    return await serviceClient.getCurrentOnboardingStage(
+    console.log('port number :',await NativeClient.getHost())
+    return await ServiceClient.getCurrentOnboardingStage(
       EmptyRequest.create(),
       {},
     ).response
@@ -23,5 +19,8 @@ class OnboardingRpcHelper {
   }
 }
 
+/**
+ * Constant to support the RPC call functions in any screen or component lifecycle of the app
+ */
 export const OnboardingRpcCaller: OnboardingRpcHelper =
   new OnboardingRpcHelper();

--- a/src/Rpc/OnboardingRpcCaller.ts
+++ b/src/Rpc/OnboardingRpcCaller.ts
@@ -1,0 +1,27 @@
+import {GrpcClient} from '@mitch528/react-native-grpc';
+import {GetCurrentOnboardingStageResponse} from '../gencode/protos-frontend/onboarding/rpc';
+import {FrontendServiceClient} from '../gencode/protos-frontend/frontend/FrontendService.client';
+import {RNGrpcTransport} from './RNTransport';
+import {EmptyRequest} from '../gencode/protos-frontend/generic/GenericMessages';
+
+class OnboardingRpcHelper {
+  public async getCurrentOnboardingStage() {
+    const nativeClient = GrpcClient;
+    nativeClient.setHost('0.tcp.in.ngrok.io:12935');
+    nativeClient.setInsecure(true);
+    
+    const serviceClient = new FrontendServiceClient(
+      new RNGrpcTransport(nativeClient),
+    );
+    
+    console.log('port number :',await nativeClient.getHost())
+    return await serviceClient.getCurrentOnboardingStage(
+      EmptyRequest.create(),
+      {},
+    ).response
+    
+  }
+}
+
+export const OnboardingRpcCaller: OnboardingRpcHelper =
+  new OnboardingRpcHelper();

--- a/src/Rpc/RNTransport.ts
+++ b/src/Rpc/RNTransport.ts
@@ -1,0 +1,106 @@
+/* eslint-disable eslint-comments/no-unlimited-disable */
+import {
+    ClientStreamingCall,
+    DuplexStreamingCall,
+    mergeRpcOptions,
+    MethodInfo,
+    RpcOptions,
+    RpcOutputStreamController,
+    RpcStatus,
+    RpcTransport,
+    ServerStreamingCall,
+    UnaryCall,
+  } from '@protobuf-ts/runtime-rpc';
+  import { GrpcClient, GrpcMetadata } from '@mitch528/react-native-grpc';
+  import { AbortSignal } from 'abort-controller';
+  
+  /* eslint-disable */
+  
+  function makePath(method: MethodInfo): string {
+    return `/${method.service.typeName}/${method.name}`;
+  }
+  
+  export class RNGrpcTransport implements RpcTransport {
+    constructor(private client: typeof GrpcClient) {
+    }
+  
+    mergeOptions(options?: Partial<RpcOptions>): RpcOptions {
+      return mergeRpcOptions({}, options);
+    }
+    unary<I extends object, O extends object>(method: MethodInfo<I, O>, input: I, options: RpcOptions): UnaryCall<I, O> {
+      const headers = options.meta || {};
+      const data = method.I.toBinary(input, options.binaryOptions);
+      const grpcMethod = makePath(method);
+  
+      const call = this.client.unaryCall(
+        grpcMethod,
+        data,
+        headers as GrpcMetadata
+      );
+  
+      if (options.abort) {
+        const signal = options.abort as AbortSignal;
+  
+        signal.addEventListener('abort', () => {
+          call.cancel();
+        });
+      }
+  
+      const response = call.response.then(resp => method.O.fromBinary(resp));
+      const status = call.trailers.then<RpcStatus, RpcStatus>(() => ({
+        code: 0,
+        detail: '',
+      } as any), ({ error, code }) => ({
+        code: code,
+        detail: error
+      }));
+  
+      return new UnaryCall(method, headers, input, call.headers, response, status, call.trailers);
+    }
+    serverStreaming<I extends object, O extends object>(method: MethodInfo<I, O>, input: I, options: RpcOptions): ServerStreamingCall<I, O> {
+      const headers = options.meta || {};
+      const data = method.I.toBinary(input, options.binaryOptions);
+      const grpcMethod = makePath(method);
+  
+      const call = this.client.serverStreamCall(grpcMethod, data, headers as GrpcMetadata);
+      const status = call.trailers.then<RpcStatus, RpcStatus>(() => ({
+        code: 0,
+        detail: '',
+      } as any), ({ error, code }) => ({
+        code: code,
+        detail: error
+      }));
+  
+      const outStream = new RpcOutputStreamController<O>();
+  
+      call.responses.on('data', (data: Uint8Array) => {
+        outStream.notifyMessage(method.O.fromBinary(data));
+      });
+  
+      call.responses.on('complete', () => {
+        if (!outStream.closed) {
+          outStream.notifyComplete();
+        }
+      });
+  
+      call.responses.on('error', (reason: Error) => {
+        outStream.notifyError(reason);
+      });
+  
+      if (options.abort) {
+        const signal = options.abort as AbortSignal;
+  
+        signal.addEventListener('abort', () => {
+          call.cancel();
+        });
+      }
+  
+      return new ServerStreamingCall(method, headers, input, call.headers, outStream, status, call.trailers);
+    }
+    clientStreaming<I extends object, O extends object>(method: MethodInfo<I, O>, options: RpcOptions): ClientStreamingCall<I, O> {
+      throw new Error('Method not implemented.');
+    }
+    duplex<I extends object, O extends object>(method: MethodInfo<I, O>, options: RpcOptions): DuplexStreamingCall<I, O> {
+      throw new Error('Method not implemented.');
+    }
+  }


### PR DESCRIPTION
## Description
- Introduced a new Class named `OnboardingRpcCaller`, can be used to list down the RPC calls happening for the onboarding team
- A new transport was needed to do the Unary RPC calls hence had built the `RNGrpcTransport`
- `RNGrpcTransport` is designed currently only for `Unary RPC calls` and not streaming purposes, but is able to solve all our current use cases as we can poll these RPCs which will behave as same as streaming
- Enabled `TextEncoder` so that RPC Calls can happen without any error or the `Unary` definitions from `protobuf-js`
- Dependencies for now :  `protobuf-js`
- Server Config YAML is not in use for now, will integrate once Config Helper is in